### PR TITLE
Customisation 001

### DIFF
--- a/Sources/MarkdownKit/AttributedString/AttributedStringGenerator.swift
+++ b/Sources/MarkdownKit/AttributedString/AttributedStringGenerator.swift
@@ -19,9 +19,9 @@
 //
 
 #if os(iOS) || os(watchOS) || os(tvOS)
-  import UIKit
+import UIKit
 #elseif os(macOS)
-  import Cocoa
+import Cocoa
 #endif
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
@@ -33,402 +33,544 @@
 /// override how individual Markdown structures are converted into attributed strings.
 ///
 open class AttributedStringGenerator {
-
-  /// Customized html generator to work around limitations of the current HTML to
-  /// `NSAttributedString` conversion logic provided by the operating system.
-  open class InternalHtmlGenerator: HtmlGenerator {
-    var outer: AttributedStringGenerator?
     
-    public init(outer: AttributedStringGenerator) {
-      self.outer = outer
-    }
-
-    open override func generate(block: Block, tight: Bool = false) -> String {
-      switch block {
-        case .list(_, _, _):
-          return super.generate(block: block, tight: tight) + "<p style=\"margin: 0;\" />\n"
-        case .indentedCode(_),
-             .fencedCode(_, _):
-          return "<table style=\"width: 100%; margin-bottom: 3px;\"><tbody><tr>" +
-                 "<td class=\"codebox\">" +
-                 super.generate(block: block, tight: tight) +
-                 "</td></tr></tbody></table><p style=\"margin: 0;\" />\n"
-        case .blockquote(let blocks):
-          return "<table class=\"blockquote\"><tbody><tr>" +
-                 "<td class=\"quote\" /><td style=\"width: 0.5em;\" /><td>\n" +
-                 self.generate(blocks: blocks) +
-                 "</td></tr><tr style=\"height: 0;\"><td /><td /><td /></tr></tbody></table>\n"
-        case .thematicBreak:
-          return "<p><table style=\"width: 100%; margin-bottom: 3px;\"><tbody>" +
-                 "<tr><td class=\"thematic\"></td></tr></tbody></table></p>\n"
-        case .table(let header, let align, let rows):
-          var tagsuffix: [String] = []
-          for a in align {
-            switch a {
-              case .undefined:
-                tagsuffix.append(">")
-              case .left:
-                tagsuffix.append(" align=\"left\">")
-              case .right:
-                tagsuffix.append(" align=\"right\">")
-              case .center:
-                tagsuffix.append(" align=\"center\">")
+    /// Customized html generator to work around limitations of the current HTML to
+    /// `NSAttributedString` conversion logic provided by the operating system.
+    open class InternalHtmlGenerator: HtmlGenerator {
+        var outer: AttributedStringGenerator?
+        
+        public init(outer: AttributedStringGenerator) {
+            self.outer = outer
+        }
+        
+        open override func generate(block: Block, tight: Bool = false) -> String {
+            switch block {
+            case .list(_, _, _):
+                let listHtml = super.generate(block: block, tight: tight)
+                print("listHtml: \(super.generate(block: block, tight: tight)), tight: \(tight)")
+                return listHtml
+            case .indentedCode(_),
+                    .fencedCode(_, _):
+                return "<table style=\"width: 100%; margin-bottom: 3px;\"><tbody><tr>" +
+                "<td class=\"codebox\">" +
+                super.generate(block: block, tight: tight) +
+                "</td></tr></tbody></table><p style=\"margin: 0;\" />\n"
+            case .blockquote(let blocks):
+                return "<table class=\"blockquote\"><tbody><tr>" +
+                "<td class=\"quote\" /><td style=\"width: 0.5em;\" /><td>\n" +
+                self.generate(blocks: blocks) +
+                "</td></tr><tr style=\"height: 0;\"><td /><td /><td /></tr></tbody></table>\n"
+            case .thematicBreak:
+                return "<table class=\"thematic\" style=\"width: 100%;\"><tbody class=\"thematic\">" +
+                "<tr class=\"thematic\"><td class=\"thematic\"></td></tr></tbody></table>"
+            case .table(let header, let align, let rows):
+                var tagsuffix: [String] = []
+                for a in align {
+                    switch a {
+                    case .undefined:
+                        tagsuffix.append(">")
+                    case .left:
+                        tagsuffix.append(" align=\"left\">")
+                    case .right:
+                        tagsuffix.append(" align=\"right\">")
+                    case .center:
+                        tagsuffix.append(" align=\"center\">")
+                    }
+                }
+                var html = "<table class=\"main\"" +
+                "cellpadding=\"\(self.outer?.tableCellPadding ?? 2)\"><thead class=\"main\"><tr class=\"main\">\n"
+                var i = 0
+                for head in header {
+                    html += "<th class=\"main\" \(tagsuffix[i])\(self.generate(text: head))&nbsp;</th>"
+                    i += 1
+                }
+                html += "\n</tr></thead><tbody class=\"main\">\n"
+                for row in rows {
+                    html += "<tr class=\"main\">"
+                    i = 0
+                    for cell in row {
+                        html += "<td  class=\"main\" \(tagsuffix[i])\(self.generate(text: cell))&nbsp;</td>"
+                        i += 1
+                    }
+                    html += "</tr>\n"
+                }
+                html += "</tbody></table><p style=\"margin: 0;\" />\n"
+                return html
+            case .definitionList(let defs):
+                var html = "<dl>\n"
+                for def in defs {
+                    html += "<dt>" + self.generate(text: def.item) + "</dt>\n"
+                    for descr in def.descriptions {
+                        if case .listItem(_, _, let blocks) = descr {
+                            html += "<dd>" + self.generate(blocks: blocks) + "</dd>\n"
+                        }
+                    }
+                }
+                html += "</dl>\n"
+                return html
+            case .custom(let customBlock):
+                return customBlock.generateHtml(via: self, and: self.outer, tight: tight)
+            default:
+                return super.generate(block: block, tight: tight)
             }
-          }
-          var html = "<table class=\"mtable\" " +
-                     "cellpadding=\"\(self.outer?.tableCellPadding ?? 2)\"><thead><tr>\n"
-          var i = 0
-          for head in header {
-            html += "<th\(tagsuffix[i])\(self.generate(text: head))&nbsp;</th>"
-            i += 1
-          }
-          html += "\n</tr></thead><tbody>\n"
-          for row in rows {
-            html += "<tr>"
-            i = 0
-            for cell in row {
-              html += "<td\(tagsuffix[i])\(self.generate(text: cell))&nbsp;</td>"
-              i += 1
+        }
+        
+        open override func generate(textFragment fragment: TextFragment) -> String {
+            switch fragment {
+            case .image(let text, let uri, let title):
+                let titleAttr = title == nil ? "" : " title=\"\(title!)\""
+                if let uriStr = uri {
+                    let url = URL(string: uriStr)
+                    if (url?.scheme == nil) || (url?.isFileURL ?? false),
+                       let baseUrl = self.outer?.imageBaseUrl {
+                        let url = URL(fileURLWithPath: uriStr, relativeTo: baseUrl)
+                        if url.isFileURL {
+                            return "<a href=\"\(url.absoluteString)\" alt=\"\(text.rawDescription)\"\(titleAttr)/>"
+                        }
+                    }
+                    return "<a href=\"\(uriStr)\">\(text.rawDescription.isEmpty ? titleAttr:text.rawDescription)</a>"
+                } else {
+                    return self.generate(text: text)
+                }
+            case .custom(let customTextFragment):
+                return customTextFragment.generateHtml(via: self, and: self.outer)
+            default:
+                return super.generate(textFragment: fragment)
             }
-            html += "</tr>\n"
-          }
-          html += "</tbody></table><p style=\"margin: 0;\" />\n"
-          return html
-        case .definitionList(let defs):
-          var html = "<dl>\n"
-          for def in defs {
-            html += "<dt>" + self.generate(text: def.item) + "</dt>\n"
-            for descr in def.descriptions {
-              if case .listItem(_, _, let blocks) = descr {
-                html += "<dd>" + self.generate(blocks: blocks) + "</dd>\n"
-              }
-            }
-          }
-          html += "</dl>\n"
-          return html
-        case .custom(let customBlock):
-          return customBlock.generateHtml(via: self, and: self.outer, tight: tight)
-        default:
-          return super.generate(block: block, tight: tight)
-      }
+        }
     }
     
-    open override func generate(textFragment fragment: TextFragment) -> String {
-      switch fragment {
-        case .image(let text, let uri, let title):
-          let titleAttr = title == nil ? "" : " title=\"\(title!)\""
-          if let uriStr = uri {
-            let url = URL(string: uriStr)
-            if (url?.scheme == nil) || (url?.isFileURL ?? false),
-               let baseUrl = self.outer?.imageBaseUrl {
-              let url = URL(fileURLWithPath: uriStr, relativeTo: baseUrl)
-              if url.isFileURL {
-                return "<img src=\"\(url.absoluteString)\"" +
-                       " alt=\"\(text.rawDescription)\"\(titleAttr)/>"
-              }
+    /// Default `AttributedStringGenerator` implementation.
+    public static let standard: AttributedStringGenerator = AttributedStringGenerator()
+    
+    /// The base font size.
+    public let fontSize: Float
+    
+    /// The base font family.
+    public let fontFamily: String
+    
+    /// The base font color.
+    public let fontColor: String
+    
+    /// The code font size.
+    public let codeFontSize: Float
+    
+    /// The code font family.
+    public let codeFontFamily: String
+    
+    /// The code font color.
+    public let codeFontColor: String
+    
+    /// The code block font size.
+    public let codeBlockFontSize: Float
+    
+    /// The code block font color.
+    public let codeBlockFontColor: String
+    
+    /// The code block background color.
+    public let codeBlockBackground: String
+    
+    /// The border color (used for code blocks and for thematic breaks).
+    public let borderColor: String
+    
+    /// The blockquote color.
+    public let blockquoteColor: String
+    
+    /// The color of H1 headers.
+    public let h1Color: String
+    
+    /// The color of H2 headers.
+    public let h2Color: String
+    
+    /// The color of H3 headers.
+    public let h3Color: String
+    
+    /// The color of H4 headers.
+    public let h4Color: String
+    
+    /// The maximum width of an image
+    public let maxImageWidth: String?
+    
+    /// The maximum height of an image
+    public let maxImageHeight: String?
+    
+    /// Custom CSS style
+    public let customStyle: String
+    
+    /// If provided, this URL is used as a base URL for relative image links
+    public let imageBaseUrl: URL?
+    
+    /// Responsible for styling the main table with actual rows and columns
+    public let tableBorderWidth: Float
+    public let tableBorderStyle: String
+    public let tableBorderColor: String
+    public let tableHeaderFontSize: Float
+    public let tableHeaderFontColor: String
+    public let tableHeaderBackgroundColor: String
+    public let tableEvenRowFontSize: Float
+    public let tableEvenRowFontColor: String
+    public let tableEvenRowBackgroundColor: String
+    public let tableOddRowFontSize: Float
+    public let tableOddRowFontColor: String
+    public let tableOddRowBackgroundColor: String
+    public let tableEvenDataFontSize: Float
+    public let tableEvenDataFontColor: String
+    public let tableEvenDataBackgroundColor: String
+    public let tableOddDataFontSize: Float
+    public let tableOddDataFontColor: String
+    public let tableOddDataBackgroundColor: String
+    
+    ///Responsible for thematic break styling
+    public let thematicBorderWidth: Float
+    public let thematicBorderStyle: String
+    public let thematicBorderColor: String
+    
+    /// Constructor providing customization options for the generated `NSAttributedString` markup.
+    public init(fontSize: Float = 14.0,
+                fontFamily: String = "\"Times New Roman\",Times,serif",
+                fontColor: String = mdDefaultColor,
+                codeFontSize: Float = 13.0,
+                codeFontFamily: String =
+                "\"Consolas\",\"Andale Mono\",\"Courier New\",Courier,monospace",
+                codeFontColor: String = mdDefaultColor,
+                codeBlockFontSize: Float = 12.0,
+                codeBlockFontColor: String = mdDefaultColor,
+                codeBlockBackground: String = mdDefaultBackgroundColor,
+                borderColor: String = "#bbb",
+                blockquoteColor: String = "#99c",
+                h1Color: String = mdDefaultColor,
+                h2Color: String = mdDefaultColor,
+                h3Color: String = mdDefaultColor,
+                h4Color: String = mdDefaultColor,
+                maxImageWidth: String? = nil,
+                maxImageHeight: String? = nil,
+                customStyle: String = "",
+                imageBaseUrl: URL? = nil,
+                
+                tableBorderWidth: Float = 0.1,
+                tableBorderStyle: String = "solid",
+                tableBorderColor: String = "black",
+                tableHeaderFontSize: Float = 15.0,
+                tableHeaderFontColor: String = "black",
+                tableHeaderBackgroundColor: String = "#00000000",
+                tableEvenRowFontSize: Float = 14.0,
+                tableEvenRowFontColor: String = "black",
+                tableEvenRowBackgroundColor: String = "#00000030",
+                tableOddRowFontSize: Float = 14.0,
+                tableOddRowFontColor: String = "black",
+                tableOddRowBackgroundColor: String = "#00000000",
+                tableEvenDataFontSize: Float = 14.0,
+                tableEvenDataFontColor: String = "black",
+                tableEvenDataBackgroundColor: String = "",
+                tableOddDataFontSize: Float = 14.0,
+                tableOddDataFontColor: String = "black",
+                tableOddDataBackgroundColor: String = "",
+                
+                thematicBorderWidth: Float = 1,
+                thematicBorderStyle: String = "solid",
+                thematicBorderColor: String = "#00000030"
+                
+    ) {
+        self.fontSize = fontSize
+        self.fontFamily = fontFamily
+        self.fontColor = fontColor
+        self.codeFontSize = codeFontSize
+        self.codeFontFamily = codeFontFamily
+        self.codeFontColor = codeFontColor
+        self.codeBlockFontSize = codeBlockFontSize
+        self.codeBlockFontColor = codeBlockFontColor
+        self.codeBlockBackground = codeBlockBackground
+        self.borderColor = borderColor
+        self.blockquoteColor = blockquoteColor
+        self.h1Color = h1Color
+        self.h2Color = h2Color
+        self.h3Color = h3Color
+        self.h4Color = h4Color
+        self.maxImageWidth = maxImageWidth
+        self.maxImageHeight = maxImageHeight
+        self.customStyle = customStyle
+        self.imageBaseUrl = imageBaseUrl
+        
+        self.tableBorderWidth = tableBorderWidth
+        self.tableBorderStyle = tableBorderStyle
+        self.tableBorderColor = tableBorderColor
+        self.tableHeaderFontSize = tableHeaderFontSize
+        self.tableHeaderFontColor = tableHeaderFontColor
+        self.tableHeaderBackgroundColor = tableHeaderBackgroundColor
+        self.tableEvenRowFontSize = tableEvenRowFontSize
+        self.tableEvenRowFontColor = tableEvenRowFontColor
+        self.tableEvenRowBackgroundColor = tableEvenRowBackgroundColor
+        self.tableOddRowFontSize = tableOddRowFontSize
+        self.tableOddRowFontColor = tableOddRowFontColor
+        self.tableOddRowBackgroundColor = tableOddRowBackgroundColor
+        self.tableEvenDataFontSize = tableEvenDataFontSize
+        self.tableEvenDataFontColor = tableEvenDataFontColor
+        self.tableEvenDataBackgroundColor = tableEvenDataBackgroundColor
+        self.tableOddDataFontSize = tableOddDataFontSize
+        self.tableOddDataFontColor = tableOddDataFontColor
+        self.tableOddDataBackgroundColor = tableOddDataBackgroundColor
+        
+        self.thematicBorderWidth = thematicBorderWidth
+        self.thematicBorderStyle = thematicBorderStyle
+        self.thematicBorderColor = thematicBorderColor
+    }
+    
+    /// Generates an attributed string from the given Markdown document
+    open func generate(doc: Block) -> NSAttributedString? {
+        return self.generateAttributedString(self.htmlGenerator.generate(doc: doc))
+    }
+    
+    /// Generates an attributed string from the given Markdown blocks
+    open func generate(block: Block) -> NSAttributedString? {
+        return self.generateAttributedString(self.htmlGenerator.generate(block: block))
+    }
+    
+    /// Generates an attributed string from the given Markdown blocks
+    open func generate(blocks: Blocks) -> NSAttributedString? {
+        return self.generateAttributedString(self.htmlGenerator.generate(blocks: blocks))
+    }
+    
+    private func generateAttributedString(_ htmlBody: String) -> NSAttributedString? {
+        let htmlDoc = self.generateHtml(htmlBody)
+        let httpData = Data(htmlDoc.utf8)
+        return try? NSAttributedString(data: httpData,
+                                       options: [.documentType: NSAttributedString.DocumentType.html,
+                                                 .characterEncoding: String.Encoding.utf8.rawValue],
+                                       documentAttributes: nil)
+    }
+    
+    open var htmlGenerator: HtmlGenerator {
+        return InternalHtmlGenerator(outer: self)
+    }
+    
+    open func generateHtml(_ htmlBody: String) -> String {
+        return "<html>\n\(self.htmlHead)\n\(self.htmlBody(htmlBody))\n</html>"
+    }
+    
+    open var htmlHead: String {
+        return "<head><meta charset=\"utf-8\"/><style type=\"text/css\">\n" +
+        self.docStyle +
+        "\n</style></head>\n"
+    }
+    
+    open func htmlBody(_ body: String) -> String {
+        return "<body>\n\(body)\n</body>"
+    }
+    
+    open var docStyle: String {
+        return "body             { \(self.bodyStyle) }\n" +
+        "h1               { \(self.h1Style) }\n" +
+        "h2               { \(self.h2Style) }\n" +
+        "h3               { \(self.h3Style) }\n" +
+        "h4               { \(self.h4Style) }\n" +
+        "h5               { \(self.h4Style) }\n" +
+        "h6               { \(self.h4Style) }\n" +
+        "p                { \(self.pStyle) }\n" +
+//        "ul               { \(self.ulStyle) }\n" +
+//        "ol               { \(self.olStyle) }\n" +
+//        "li               { \(self.liStyle) }\n" +
+        "table.blockquote { \(self.blockquoteStyle) }\n" +
+        
+        //main table
+        "table.main                  { \(self.tableStyle) }\n" +
+        "thead.main th.main          { \(self.tableHeaderStyle) }\n" +
+        "tr.main:nth-child(even)     { \(self.tableEvenRowStyle) }\n" +
+        "tr.main:nth-child(odd)      { \(self.tableOddRowStyle) }\n" +
+        "td.main:nth-child(even)     { \(self.tableEvenDataStyle) }\n" +
+        "td.main:nth-child(odd)      { \(self.tableOddDataStyle) }\n" +
+        
+        "pre              { \(self.preStyle) }\n" +
+        "code             { \(self.codeStyle) }\n" +
+        "pre code         { \(self.preCodeStyle) }\n" +
+        "td.codebox       { \(self.codeBoxStyle) }\n" +
+        
+        //thematic break table
+        "table.thematic   { \(self.thematicBreakTableStyle) }\n" +
+        "tbody.thematic   { \(self.thematicBreakTableStyle) }\n" +
+        "tr.thematic      { \(self.thematicBreakTableRowStyle) }\n" +
+        "td.thematic      { \(self.thematicBreakTableDataStyle) }\n" +
+        
+        "td.quote         { \(self.quoteStyle) }\n" +
+        "img              { \(self.imgStyle) }\n" +
+        "dt {\n" +
+        "  font-weight: bold;\n" +
+        "  margin: 0.6em 0 0.4em 0;\n" +
+        "}\n" +
+        "dd {\n" +
+        "  margin: 0.5em 0 1em 2em;\n" +
+        "  padding: 0.5em 0 1em 2em;\n" +
+        "}\n" +
+        "\(self.customStyle)\n"
+    }
+    
+    open var bodyStyle: String {
+        return "font-size: \(self.fontSize)px;" +
+        "font-family: \(self.fontFamily);" +
+        "color: \(self.fontColor);"
+    }
+    
+    open var h1Style: String {
+        return "font-size: \(self.fontSize + 6)px;" +
+        "color: \(self.h1Color);" +
+        "margin: 0.7em 0 0.5em 0;"
+    }
+    
+    open var h2Style: String {
+        return "font-size: \(self.fontSize + 4)px;" +
+        "color: \(self.h2Color);" +
+        "margin: 0.6em 0 0.4em 0;"
+    }
+    
+    open var h3Style: String {
+        return "font-size: \(self.fontSize + 2)px;" +
+        "color: \(self.h3Color);" +
+        "margin: 0.5em 0 0.3em 0;"
+    }
+    
+    open var h4Style: String {
+        return "font-size: \(self.fontSize + 1)px;" +
+        "color: \(self.h4Color);" +
+        "margin: 0.5em 0 0.3em 0;"
+    }
+    
+    open var pStyle: String {
+        return "margin: 0.7em 0;"
+    }
+    
+    open var ulStyle: String {
+        return "margin: 0.7em 0;"
+    }
+    
+    open var olStyle: String {
+        return "margin: 0.7em 0;"
+    }
+    
+    open var liStyle: String {
+        return "margin-left: 0.25em;" +
+        "margin-bottom: 0.1em;"
+    }
+    
+    open var preStyle: String {
+        return "background: \(self.codeBlockBackground);"
+    }
+    
+    open var codeStyle: String {
+        return "font-size: \(self.codeFontSize)px;" +
+        "font-family: \(self.codeFontFamily);" +
+        "color: \(self.codeFontColor);" +
+        "background: \(self.codeBlockBackground);" +
+        "border: 1px solid \(self.borderColor);"
+    }
+    
+    open var preCodeStyle: String {
+        return "font-size: \(self.codeBlockFontSize)px;" +
+        "font-family: \(self.codeFontFamily);" +
+        "color: \(self.codeBlockFontColor);"
+    }
+    
+    open var codeBoxStyle: String {
+        return "font-size: \(self.codeFontSize)px;" +
+        "font-family: \(self.codeFontFamily);" +
+        "color: \(self.codeFontColor);" +
+        "background: \(self.codeBlockBackground);" +
+        "border: 1px solid \(self.borderColor);" +
+        "padding: 0.5em;" +
+        "width: 100%;"
+    }
+    
+    open var thematicBreakTableStyle: String {
+        return "border-collapse: collapse;" +
+        "border-top: \(self.thematicBorderWidth)px \(self.thematicBorderStyle) \(self.thematicBorderColor);" +
+        "table-layout: fixed;" +
+        "width:100%;"
+    }
+    
+    open var thematicBreakTableRowStyle: String {
+        return ""
+    }
+    
+    open var thematicBreakTableDataStyle: String {
+        return ""
+    }
+    
+    open var blockquoteStyle: String {
+        return "width: 100%;" +
+        "margin: 0.3em 0;" +
+        "font-size: \(self.fontSize)px;"
+    }
+    
+    open var quoteStyle: String {
+        return "background: \(self.blockquoteColor);" +
+        "width: 0.4em;"
+    }
+    
+    open var imgStyle: String {
+        if let maxWidth = self.maxImageWidth {
+            if let maxHeight = self.maxImageHeight {
+                return "max-width: \(maxWidth) !important;max-height: \(maxHeight) !important;" +
+                "width: auto;height: auto;"
+            } else {
+                return "max-height: 100%;max-width: \(maxWidth) !important;width: auto;height: auto;"
             }
-            return "<img src=\"\(uriStr)\" alt=\"\(text.rawDescription)\"\(titleAttr)/>"
-          } else {
-            return self.generate(text: text)
-          }
-        case .custom(let customTextFragment):
-          return customTextFragment.generateHtml(via: self, and: self.outer)
-        default:
-          return super.generate(textFragment: fragment)
-      }
+        } else if let maxHeight = self.maxImageHeight {
+            return "max-width: 100%;max-height: \(maxHeight) !important;width: auto;height: auto;"
+        } else {
+            return ""
+        }
     }
-  }
-
-  /// Default `AttributedStringGenerator` implementation.
-  public static let standard: AttributedStringGenerator = AttributedStringGenerator()
-  
-  /// The base font size.
-  public let fontSize: Float
-
-  /// The base font family.
-  public let fontFamily: String
-
-  /// The base font color.
-  public let fontColor: String
-
-  /// The code font size.
-  public let codeFontSize: Float
-
-  /// The code font family.
-  public let codeFontFamily: String
-
-  /// The code font color.
-  public let codeFontColor: String
-
-  /// The code block font size.
-  public let codeBlockFontSize: Float
-
-  /// The code block font color.
-  public let codeBlockFontColor: String
-
-  /// The code block background color.
-  public let codeBlockBackground: String
-
-  /// The border color (used for code blocks and for thematic breaks).
-  public let borderColor: String
-
-  /// The blockquote color.
-  public let blockquoteColor: String
-
-  /// The color of H1 headers.
-  public let h1Color: String
-
-  /// The color of H2 headers.
-  public let h2Color: String
-
-  /// The color of H3 headers.
-  public let h3Color: String
-
-  /// The color of H4 headers.
-  public let h4Color: String
-
-  /// The maximum width of an image
-  public let maxImageWidth: String?
-  
-  /// The maximum height of an image
-  public let maxImageHeight: String?
-  
-  /// Custom CSS style
-  public let customStyle: String
-  
-  /// If provided, this URL is used as a base URL for relative image links
-  public let imageBaseUrl: URL?
-  
-  
-  /// Constructor providing customization options for the generated `NSAttributedString` markup.
-  public init(fontSize: Float = 14.0,
-              fontFamily: String = "\"Times New Roman\",Times,serif",
-              fontColor: String = mdDefaultColor,
-              codeFontSize: Float = 13.0,
-              codeFontFamily: String =
-                                "\"Consolas\",\"Andale Mono\",\"Courier New\",Courier,monospace",
-              codeFontColor: String = mdDefaultColor,
-              codeBlockFontSize: Float = 12.0,
-              codeBlockFontColor: String = mdDefaultColor,
-              codeBlockBackground: String = mdDefaultBackgroundColor,
-              borderColor: String = "#bbb",
-              blockquoteColor: String = "#99c",
-              h1Color: String = mdDefaultColor,
-              h2Color: String = mdDefaultColor,
-              h3Color: String = mdDefaultColor,
-              h4Color: String = mdDefaultColor,
-              maxImageWidth: String? = nil,
-              maxImageHeight: String? = nil,
-              customStyle: String = "",
-              imageBaseUrl: URL? = nil) {
-    self.fontSize = fontSize
-    self.fontFamily = fontFamily
-    self.fontColor = fontColor
-    self.codeFontSize = codeFontSize
-    self.codeFontFamily = codeFontFamily
-    self.codeFontColor = codeFontColor
-    self.codeBlockFontSize = codeBlockFontSize
-    self.codeBlockFontColor = codeBlockFontColor
-    self.codeBlockBackground = codeBlockBackground
-    self.borderColor = borderColor
-    self.blockquoteColor = blockquoteColor
-    self.h1Color = h1Color
-    self.h2Color = h2Color
-    self.h3Color = h3Color
-    self.h4Color = h4Color
-    self.maxImageWidth = maxImageWidth
-    self.maxImageHeight = maxImageHeight
-    self.customStyle = customStyle
-    self.imageBaseUrl = imageBaseUrl
-  }
-
-  /// Generates an attributed string from the given Markdown document
-  open func generate(doc: Block) -> NSAttributedString? {
-    return self.generateAttributedString(self.htmlGenerator.generate(doc: doc))
-  }
-
-  /// Generates an attributed string from the given Markdown blocks
-  open func generate(block: Block) -> NSAttributedString? {
-    return self.generateAttributedString(self.htmlGenerator.generate(block: block))
-  }
-
-  /// Generates an attributed string from the given Markdown blocks
-  open func generate(blocks: Blocks) -> NSAttributedString? {
-    return self.generateAttributedString(self.htmlGenerator.generate(blocks: blocks))
-  }
-  
-  private func generateAttributedString(_ htmlBody: String) -> NSAttributedString? {
-    let htmlDoc = self.generateHtml(htmlBody)
-    let httpData = Data(htmlDoc.utf8)
-    return try? NSAttributedString(data: httpData,
-                                   options: [.documentType: NSAttributedString.DocumentType.html,
-                                             .characterEncoding: String.Encoding.utf8.rawValue],
-                                   documentAttributes: nil)
-  }
-  
-  open var htmlGenerator: HtmlGenerator {
-    return InternalHtmlGenerator(outer: self)
-  }
-  
-  open func generateHtml(_ htmlBody: String) -> String {
-    return "<html>\n\(self.htmlHead)\n\(self.htmlBody(htmlBody))\n</html>"
-  }
-  
-  open var htmlHead: String {
-    return "<head><meta charset=\"utf-8\"/><style type=\"text/css\">\n" +
-           self.docStyle +
-           "\n</style></head>\n"
-  }
-
-  open func htmlBody(_ body: String) -> String {
-    return "<body>\n\(body)\n</body>"
-  }
-
-  open var docStyle: String {
-    return "body             { \(self.bodyStyle) }\n" +
-           "h1               { \(self.h1Style) }\n" +
-           "h2               { \(self.h2Style) }\n" +
-           "h3               { \(self.h3Style) }\n" +
-           "h4               { \(self.h4Style) }\n" +
-           "p                { \(self.pStyle) }\n" +
-           "ul               { \(self.ulStyle) }\n" +
-           "ol               { \(self.olStyle) }\n" +
-           "li               { \(self.liStyle) }\n" +
-           "table.blockquote { \(self.blockquoteStyle) }\n" +
-           "table.mtable     { \(self.tableStyle) }\n" +
-           "table.mtable thead th { \(self.tableHeaderStyle) }\n" +
-           "pre              { \(self.preStyle) }\n" +
-           "code             { \(self.codeStyle) }\n" +
-           "pre code         { \(self.preCodeStyle) }\n" +
-           "td.codebox       { \(self.codeBoxStyle) }\n" +
-           "td.thematic      { \(self.thematicBreakStyle) }\n" +
-           "td.quote         { \(self.quoteStyle) }\n" +
-           "img              { \(self.imgStyle) }\n" +
-           "dt {\n" +
-           "  font-weight: bold;\n" +
-           "  margin: 0.6em 0 0.4em 0;\n" +
-           "}\n" +
-           "dd {\n" +
-           "  margin: 0.5em 0 1em 2em;\n" +
-           "  padding: 0.5em 0 1em 2em;\n" +
-           "}\n" +
-           "\(self.customStyle)\n"
-  }
-
-  open var bodyStyle: String {
-    return "font-size: \(self.fontSize)px;" +
-           "font-family: \(self.fontFamily);" +
-           "color: \(self.fontColor);"
-  }
-
-  open var h1Style: String {
-    return "font-size: \(self.fontSize + 6)px;" +
-           "color: \(self.h1Color);" +
-           "margin: 0.7em 0 0.5em 0;"
-  }
-
-  open var h2Style: String {
-    return "font-size: \(self.fontSize + 4)px;" +
-           "color: \(self.h2Color);" +
-           "margin: 0.6em 0 0.4em 0;"
-  }
-
-  open var h3Style: String {
-    return "font-size: \(self.fontSize + 2)px;" +
-           "color: \(self.h3Color);" +
-           "margin: 0.5em 0 0.3em 0;"
-  }
-
-  open var h4Style: String {
-    return "font-size: \(self.fontSize + 1)px;" +
-           "color: \(self.h4Color);" +
-           "margin: 0.5em 0 0.3em 0;"
-  }
-
-  open var pStyle: String {
-    return "margin: 0.7em 0;"
-  }
-
-  open var ulStyle: String {
-    return "margin: 0.7em 0;"
-  }
-
-  open var olStyle: String {
-    return "margin: 0.7em 0;"
-  }
-
-  open var liStyle: String {
-    return "margin-left: 0.25em;" +
-           "margin-bottom: 0.1em;"
-  }
-
-  open var preStyle: String {
-    return "background: \(self.codeBlockBackground);"
-  }
-
-  open var codeStyle: String {
-    return "font-size: \(self.codeFontSize)px;" +
-           "font-family: \(self.codeFontFamily);" +
-           "color: \(self.codeFontColor);"
-  }
-
-  open var preCodeStyle: String {
-    return "font-size: \(self.codeBlockFontSize)px;" +
-           "font-family: \(self.codeFontFamily);" +
-           "color: \(self.codeBlockFontColor);"
-  }
-
-  open var codeBoxStyle: String {
-    return "background: \(self.codeBlockBackground);" +
-           "width: 100%;" +
-           "border: 1px solid \(self.borderColor);" +
-           "padding: 0.5em;"
-  }
-
-  open var thematicBreakStyle: String {
-    return "border-bottom: 1px solid \(self.borderColor);"
-  }
-
-  open var blockquoteStyle: String {
-    return "width: 100%;" +
-           "margin: 0.3em 0;" +
-           "font-size: \(self.fontSize)px;"
-  }
-  
-  open var quoteStyle: String {
-    return "background: \(self.blockquoteColor);" +
-           "width: 0.4em;"
-  }
-  
-  open var imgStyle: String {
-    if let maxWidth = self.maxImageWidth {
-      if let maxHeight = self.maxImageHeight {
-        return "max-width: \(maxWidth) !important;max-height: \(maxHeight) !important;" +
-               "width: auto;height: auto;"
-      } else {
-        return "max-height: 100%;max-width: \(maxWidth) !important;width: auto;height: auto;"
-      }
-    } else if let maxHeight = self.maxImageHeight {
-      return "max-width: 100%;max-height: \(maxHeight) !important;width: auto;height: auto;"
-    } else {
-      return ""
+    
+    open var tableStyle: String {
+        return "border-collapse: collapse;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);" +
+        "padding: 3px;" +
+        "font-size: \(self.fontSize)px;" +
+        "table-layout: fixed;" +
+        "width:100%;"
     }
-  }
-  
-  open var tableStyle: String {
-    return "border-collapse: collapse;" +
-           "margin: 0.3em 0;" +
-           "padding: 3px;" +
-           "font-size: \(self.fontSize)px;"
-  }
-  
-  open var tableHeaderStyle: String {
-    return "border-top: 1px solid #888;"
-  }
-  
-  open var tableCellPadding: Int {
-    return 2
-  }
+    
+    open var tableHeaderStyle: String {
+        "background-color: \(self.tableHeaderBackgroundColor);" +
+        "color: \(self.tableHeaderFontColor);" +
+        "font-size: \(self.tableHeaderFontSize)px;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);"
+    }
+    
+    open var tableEvenRowStyle: String {
+        return "background-color: \(self.tableEvenRowBackgroundColor);" +
+        "color: \(self.tableEvenRowFontColor);" +
+        "font-size: \(self.tableEvenRowFontSize)px;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);" +
+        "table-layout: fixed;" +
+        "width:100%;"
+    }
+    
+    open var tableOddRowStyle: String {
+        return "background-color: \(self.tableOddRowBackgroundColor);" +
+        "color: \(self.tableOddRowFontColor);" +
+        "font-size: \(self.tableOddRowFontSize)px;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);" +
+//        "display:table;" +
+        "table-layout: fixed;" +
+        "width:100%;"
+    }
+    
+    open var tableEvenDataStyle: String {
+        return "background-color: \(self.tableEvenDataBackgroundColor);" +
+        "color: \(self.tableEvenDataFontColor);" +
+        "font-size: \(self.tableEvenDataFontSize)px;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);"
+    }
+    
+    open var tableOddDataStyle: String {
+        return "background-color: \(self.tableOddDataBackgroundColor);" +
+        "color: \(self.tableOddDataFontColor);" +
+        "font-size: \(self.tableOddDataFontSize)px;" +
+        "border: \(self.tableBorderWidth)px \(self.tableBorderStyle) \(self.tableBorderColor);"
+    }
+    
+    open var tableCellPadding: Int {
+        return 2
+    }
 }
 
 #endif

--- a/Sources/MarkdownKit/HTML/HtmlGenerator.swift
+++ b/Sources/MarkdownKit/HTML/HtmlGenerator.swift
@@ -57,17 +57,17 @@ open class HtmlGenerator {
         return "<blockquote>\n" + self.generate(blocks: blocks) + "</blockquote>\n"
       case .list(let start, let tight, let blocks):
         if let startNumber = start {
-          return "<ol start=\"\(startNumber)\">\n" +
+          return "<ol start=\"\(startNumber)\">" +
                  self.generate(blocks: blocks, tight: tight) +
-                 "</ol>\n"
+                 "</ol>"
         } else {
-          return "<ul>\n" + self.generate(blocks: blocks, tight: tight) + "</ul>\n"
+          return "<ul>" + self.generate(blocks: blocks, tight: tight) + "</ul>"
         }
-      case .listItem(_, _, let blocks):
+      case .listItem(_, let tight, let blocks):
         if tight, let text = blocks.text {
-          return "<li>" + self.generate(text: text) + "</li>\n"
+          return "<li>" + self.generate(text: text) + "</li>"
         } else {
-          return "<li>" + self.generate(blocks: blocks) + "</li>\n"
+          return self.generate(blocks: blocks)
         }
       case .paragraph(let text):
         return "<p>" + self.generate(text: text) + "</p>\n"
@@ -75,18 +75,18 @@ open class HtmlGenerator {
         let tag = "h\(n > 0 && n < 7 ? n : 1)>"
         return "<\(tag)\(self.generate(text: text))</\(tag)\n"
       case .indentedCode(let lines):
-        return "<pre><code>" +
+        return "&nbsp<pre><code>" +
                self.generate(lines: lines).encodingPredefinedXmlEntities() +
-               "</code></pre>\n"
+               "</code></pre>\n&nbsp"
       case .fencedCode(let lang, let lines):
         if let language = lang {
-          return "<pre><code class=\"\(language)\">" +
+          return "&nbsp<pre><code class=\"\(language)\">" +
                  self.generate(lines: lines, separator: "").encodingPredefinedXmlEntities() +
-                 "</code></pre>\n"
+                 "</code></pre>\n&nbsp"
         } else {
-          return "<pre><code>" +
+          return "&nbsp<pre><code>" +
                  self.generate(lines: lines, separator: "").encodingPredefinedXmlEntities() +
-                 "</code></pre>\n"
+                 "</code></pre>\n&nbsp"
         }
       case .htmlBlock(let lines):
         return self.generate(lines: lines)
@@ -161,7 +161,7 @@ open class HtmlGenerator {
       case .text(let str):
         return String(str).decodingNamedCharacters().encodingPredefinedXmlEntities()
       case .code(let str):
-        return "<code>" + String(str).encodingPredefinedXmlEntities() + "</code>"
+        return "<code>&nbsp" + String(str).encodingPredefinedXmlEntities() + "&nbsp</code>"
       case .emph(let text):
         return "<em>" + self.generate(text: text) + "</em>"
       case .strong(let text):

--- a/Sources/MarkdownKit/Parser/CodeLinkHtmlTransformer.swift
+++ b/Sources/MarkdownKit/Parser/CodeLinkHtmlTransformer.swift
@@ -83,7 +83,7 @@ open class CodeLinkHtmlTransformer: InlineTransformer {
                   element = iterator.next()
                   continue loop
                 } else if isHtmlTag(content) {
-                  res.append(fragment: .html(Substring(content)))
+//                  res.append(fragment: .html(Substring(content)))
                   iterator = scanner
                   element = iterator.next()
                   continue loop

--- a/Sources/MarkdownKit/Parser/EmphasisTransformer.swift
+++ b/Sources/MarkdownKit/Parser/EmphasisTransformer.swift
@@ -31,11 +31,17 @@ open class EmphasisTransformer: InlineTransformer {
   /// be marked as "special"), and `factory` to a closure constructing the text fragment
   /// from two parameters: the first denoting whether it's double usage, and the second
   /// referring to the emphasized text.
-  public struct Emphasis {
-    let ch: Character
-    let special: Bool
-    let factory: (Bool, Text) -> TextFragment
-  }
+    public struct Emphasis {
+        let ch: Character
+        let special: Bool
+        let factory: (Bool, Text) -> TextFragment
+        
+        public init(ch: Character, special: Bool, factory: @escaping (Bool, Text) -> TextFragment) {
+            self.ch = ch
+            self.special = special
+            self.factory = factory
+        }
+    }
   
   /// Emphasis supported by default. Override this property to change the what gets
   /// supported.


### PR DESCRIPTION
## quality updates
- Removed unnecessary newlines from lists and listitems
- Tightness of listitem parsing fixed as it was not taking the value that was passed through enum func
- Added extra spacing for inline code and code block for more emphasis and room for better readability
- Added customisation of table **header** and **body** font family, font size and background color
- Segregated table classes for **main** table (containing cells like spreadsheet) as **blockquote** and **thematic break** also relies on `<table>` tag
- Fixed the thematic break table as it didn't show up before (not sure why, could be an issue with html tags or parsers)

## important
- Fixed a build error where the initialisation of `Emphasis` struct was not allowed due to the absence of a `public init` inside the definition (This is important for adding customisations programmatically like supporting **Emphasis** or **Strikethrough**)
- Images are converted to simple **URLs** and not parsed as images (my own use case, this is done to reduce the overhead of conversion of HTML to NSAttributedString, which is quite heavy and we don't want a scroll view to get stuck while the images are rendered, still not the best practice but pretty effective)
- Removed support for parsing of HTML tags (my own use case)
- H4, H5 and H6 headers are rendered with same font size (my own use case)